### PR TITLE
Add contents & id-token permissions to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,6 @@ jobs:
     needs: build
     permissions:
       pull-requests: write
+      contents: read
+      id-token: write
     secrets: inherit


### PR DESCRIPTION
Grant the publish job explicit permissions: contents: read and id-token: write in .github/workflows/publish.yml. These permissions allow the workflow to read repository contents and request OIDC id tokens (e.g., for authenticating to registries or cloud providers) when performing publish steps.