### PR TITLE
Add pollutants; group sites by SiteID+NetworkID

### DIFF
--- a/AqieHistoricaldataBackend/Atomfeed/Services/AtomDataSelectionHourlyFetchService.cs
+++ b/AqieHistoricaldataBackend/Atomfeed/Services/AtomDataSelectionHourlyFetchService.cs
@@ -163,8 +163,13 @@ namespace AqieHistoricaldataBackend.Atomfeed.Services
                 new PollutantDetails { PollutantName = "Conductivity", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/412" },
                 new PollutantDetails { PollutantName = "pH in precipitation", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/753" },
                 new PollutantDetails { PollutantName = "Rainfall", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/2076" },
-                new PollutantDetails { PollutantName = "Fluoride", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/999006" }
-
+                new PollutantDetails { PollutantName = "Fluoride", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/999006" },
+                new PollutantDetails { PollutantName = "1,3-butadiene", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/24" },
+                new PollutantDetails { PollutantName = "Benzene", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/20" },
+                new PollutantDetails { PollutantName = "Gaseous ammonia (passive)", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/35" },
+                new PollutantDetails { PollutantName = "Gaseous ammonia (active)", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/35" },
+                new PollutantDetails { PollutantName = "Gaseous ammonia (diffusion tube)", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/35" },
+                new PollutantDetails { PollutantName = "Particulate ammonium", PollutantMasterUrl = "dd.eionet.europa.eu/vocabulary/aq/pollutant/45" }
             };
             // Split and normalize the filter string
             var filterList = (filter ?? string.Empty)

--- a/AqieHistoricaldataBackend/Atomfeed/Services/AtomDataSelectionStationService.cs
+++ b/AqieHistoricaldataBackend/Atomfeed/Services/AtomDataSelectionStationService.cs
@@ -570,33 +570,33 @@ namespace AqieHistoricaldataBackend.Atomfeed.Services
             var documents = await siteCollection.Find(combinedFilter).ToListAsync();
 
             var filteredSites = documents
-                        .GroupBy(d => d.SiteID)
-                        .Select(g =>
-                        {
-                            var first = g.First();
-                            var (areaType, siteType) = SplitEnvironmentType(first.EnvironmentType);
-                            return new SiteInfo
-                            {
-                                LocalSiteId = first.SiteID,
-                                SiteName = first.SiteName,
-                                AreaType = areaType,
-                                SiteType = siteType,
-                                Latitude = first.Latitude,
-                                Longitude = first.Longitude,
-                                NetworkType = first.NetworkType,
-                                ZoneRegion = first.Region,
-                                Pollutants = g
-                                    .Where(d => d.PollutantName != null)
-                                    .Select(d => new PollutantInfo
+                                .GroupBy(d => new { d.SiteID, d.NetworkID })  
+                                .Select(g =>
+                                {
+                                    var first = g.First();
+                                    var (areaType, siteType) = SplitEnvironmentType(first.EnvironmentType);
+                                    return new SiteInfo
                                     {
-                                        Name = d.PollutantName,
-                                        StartDate = d.StartDate,
-                                        EndDate = d.EndDate
-                                    })
-                                    .ToList()
-                            };
-                        })
-                        .ToList();
+                                        LocalSiteId = first.SiteID,
+                                        SiteName = first.SiteName,
+                                        AreaType = areaType,
+                                        SiteType = siteType,
+                                        Latitude = first.Latitude,
+                                        Longitude = first.Longitude,
+                                        NetworkType = first.NetworkType,
+                                        ZoneRegion = first.Region,
+                                        Pollutants = g
+                                            .Where(d => d.PollutantName != null)
+                                            .Select(d => new PollutantInfo
+                                            {
+                                                Name = d.PollutantName,
+                                                StartDate = d.StartDate,
+                                                EndDate = d.EndDate
+                                            })
+                                            .ToList()
+                                    };
+                                })
+                                .ToList();
             return filteredSites;
         }
     }


### PR DESCRIPTION
Add several pollutant entries to AtomDataSelectionHourlyFetchService (1,3-butadiene, Benzene, gaseous ammonia variants, particulate ammonium). Update AtomDataSelectionStationService to group site documents by both SiteID and NetworkID to avoid merging sites across different networks while preserving site metadata and pollutant lists. Minor formatting adjustments.